### PR TITLE
[ENH] add neurovault data as subdataset

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -3,3 +3,7 @@
 	url = https://github.com/OpenNeuroDatasets/ds001734.git
 	datalad-id = ca05bc10-29a0-11e9-9a7b-0242ac13000d
 	datalad-url = https://github.com/OpenNeuroDatasets/ds001734.git
+[submodule "data/neurovault"]
+	path = data/neurovault
+	url = ./data/neurovault
+	datalad-id = b7b70790-7b0c-40d3-976f-c7dd49df3b86

--- a/.gitmodules
+++ b/.gitmodules
@@ -5,5 +5,6 @@
 	datalad-url = https://github.com/OpenNeuroDatasets/ds001734.git
 [submodule "data/neurovault"]
 	path = data/neurovault
-	url = ./data/neurovault
+	url = git@gin.g-node.org:/RemiGau/neurovault_narps_open_pipeline.git
+	datalad-url = git@gin.g-node.org:/RemiGau/neurovault_narps_open_pipeline.git
 	datalad-id = b7b70790-7b0c-40d3-976f-c7dd49df3b86

--- a/README.md
+++ b/README.md
@@ -258,7 +258,7 @@ as release on zenodo: https://zenodo.org/record/3528329/
 
 There are aslo included as a datalad subdataset in `data/neurovault`.
 
-Each teams results is kept in the `neurovault_downloads` in folder organized using the pattern:
+Each teams results is kept in the `orig` in folder organized using the pattern:
 
 ```
 neurovaultCollectionNumber_teamID

--- a/README.md
+++ b/README.md
@@ -249,9 +249,20 @@ File containing pipeline description is available in `/data/original`.
 Download Instructions Source: https://openneuro.org/datasets/ds001734/versions/1.0.5/download
 #### Derived data
 
-Derived data such as original stat maps from teams and reproduced stat maps can be downloaded from [NeuroVault](https://www.neurovault.org) [(Gorgolewski & al, 2015)](https://www.frontiersin.org/articles/10.3389/fninf.2015.00008/full). . 
+Derived data such as original stat maps from teams and reproduced stat maps 
+can be downloaded from [NeuroVault](https://www.neurovault.org) 
+[(Gorgolewski & al, 2015)](https://www.frontiersin.org/articles/10.3389/fninf.2015.00008/full). 
 
-*Coming soon*
+The original derivative data from the NARPS paper are available 
+as release on zenodo: https://zenodo.org/record/3528329/
+
+There are aslo included as a datalad subdataset in `data/neurovault`.
+
+Each teams results is kept in the `neurovault_downloads` in folder organized using the pattern:
+
+```
+neurovaultCollectionNumber_teamID
+```
 
 ### Contributing 
 


### PR DESCRIPTION
Work in progress... Will ping when all the data is on GIN.

closes #4 (I think)

Adding neurovault data as a subdataset.

Neurovault data will be on a repo on GIN here: https://gin.g-node.org/RemiGau/neurovault_narps_open_pipeline

Limitation of GIN: 
- requires users to create a GIN account and set up an ssh key.

Could later be improved by creating something similar to the github "forks" of openneuro datasets.

TODO

- [x] update README
