### PR TITLE
[ENH] add model U26C

### DIFF
--- a/src/models/model-U26C_smdl .json
+++ b/src/models/model-U26C_smdl .json
@@ -1,0 +1,244 @@
+{
+    "Name": "NARPS U26C",
+    "Description": "NARPS Analysis model for team U26C",
+    "BIDSModelVersion": "1.0.0",
+    "Input": {
+        "task": [
+            "MGT"
+        ]
+    },
+    "Nodes": [
+        {
+            "Level": "Run",
+            "Description": "Note: derivatives for motion correction are not implemented in pybids (added as '_der' in X below)",
+            "Name": "run",
+            "GroupBy": [
+                "run",
+                "subject"
+            ],
+            "Transformations": {
+                "Transformer": "pybids-transforms-v1",
+                "Instructions": [
+                    {
+                        "Description": "Turn the 'gain' column into a column 'trials' with only values of 1, to make sure all events are included.",
+                        "Name": "Threshold",
+                        "Input": [
+                            "gain"
+                        ],
+                        "Binarize": true,
+                        "Output": [
+                            "trials"
+                        ]
+                    },
+                    {
+                        "Description": "Create derivatives of motion correction parameters.",
+                        "Name": "Derivative",
+                        "Input": [
+                            "RotX",
+                            "RotY",
+                            "RotZ",
+                            "X",
+                            "Y",
+                            "Z"
+                        ],
+                        "Order": 1,
+                        "Initial": "NaN",
+                        "Output": [
+                            "RotX_der",
+                            "RotY_der",
+                            "RotZ_der",
+                            "X_der",
+                            "Y_der",
+                            "Z_der"
+                        ]
+                    }
+                ]
+            },
+            "Model": {
+                "X": [
+                    "trials",
+                    "gain",
+                    "loss",
+                    "RotX",
+                    "RotY",
+                    "RotZ",
+                    "X",
+                    "Y",
+                    "Z",
+                    "RotX_der",
+                    "RotY_der",
+                    "RotZ_der",
+                    "X_der",
+                    "Y_der",
+                    "Z_der",
+                    "CSF",
+                    "WhiteMatter",
+                    1
+                ],
+                "HRF": {
+                    "Description": "Only events in the 'trials' are included as convolved. All other variables are confounds EXCEPT those listed below in Software.SPM.ParametricModulation.Values",
+                    "Variables": [
+                        "trials"
+                    ],
+                    "Model": "spm"
+                },
+                "Type": "glm",
+                "Software": {
+                    "SPM": {
+                        "SerialCorrelations": "AR(1)",
+                        "Description": "list what conditions we must apply the modulation to and what values are used for the modulation.",
+                        "ParametricModulations": [
+                            {
+                                "Name": "pmod_loss",
+                                "Conditions": [
+                                    "trials"
+                                ],
+                                "Values": [
+                                    "loss"
+                                ]
+                            },
+                            {
+                                "Name": "pmod_gain",
+                                "Conditions": [
+                                    "trials"
+                                ],
+                                "Values": [
+                                    "gain"
+                                ]
+                            }
+                        ],
+                        "PolynomialExpansion": 1
+                    }
+                }
+            },
+            "DummyContrasts": {
+                "Conditions": [
+                    "trials",
+                    "gain",
+                    "loss"
+                ],
+                "Test": "t"
+            },
+            "Options": {
+                "HighPassFilterCutoffHz": 0.08
+            }
+        },
+        {
+            "Level": "Subject",
+            "Name": "subject",
+            "GroupBy": [
+                "subject",
+                "contrast"
+            ],
+            "Model": {
+                "X": [
+                    1
+                ],
+                "Type": "meta"
+            },
+            "DummyContrasts": {
+                "Test": "t"
+            }
+        },
+        {
+            "Level": "Dataset",
+            "Name": "between-groups",
+            "GroupBy": [
+                "contrast"
+            ],
+            "Model": {
+                "Type": "glm",
+                "X": [
+                    1,
+                    "group"
+                ],
+                "Formula": "0 + C(group)"
+            },
+            "Contrasts": [
+                {
+                    "Name": "range_vs_indiference",
+                    "ConditionList": [
+                        "C(group)[T.equalRange]",
+                        "C(group)[T.equalIndifference]"
+                    ],
+                    "Weights": [
+                        1,
+                        -1
+                    ],
+                    "Test": "t"
+                }
+            ]
+        },
+        {
+            "Level": "Dataset",
+            "Name": "positive",
+            "GroupBy": [
+                "contrast",
+                "group"
+            ],
+            "Model": {
+                "Type": "glm",
+                "X": [
+                    1
+                ]
+            },
+            "DummyContrasts": {
+                "Test": "t"
+            }
+        },
+        {
+            "Level": "Dataset",
+            "Name": "negative-loss",
+            "GroupBy": [
+                "contrast",
+                "group"
+            ],
+            "Model": {
+                "Type": "glm",
+                "X": [
+                    1
+                ]
+            },
+            "Contrasts": [
+                {
+                    "Name": "negative",
+                    "ConditionList": [
+                        1
+                    ],
+                    "Weights": [
+                        -1
+                    ],
+                    "Test": "t"
+                }
+            ]
+        }
+    ],
+    "Edges": [
+        {
+            "Source": "run",
+            "Destination": "subject"
+        },
+        {
+            "Source": "subject",
+            "Destination": "positive"
+        },
+        {
+            "Source": "subject",
+            "Destination": "negative-loss",
+            "Filter": {
+                "contrast": [
+                    "loss"
+                ]
+            }
+        },
+        {
+            "Source": "subject",
+            "Destination": "between-groups",
+            "Filter": {
+                "contrast": [
+                    "loss"
+                ]
+            }
+        }
+    ]
+}


### PR DESCRIPTION
- [x] add bids stats model for U26C

Had to make some choices on how to define parametric regressors for SPM.

This seems to be handled differently for SPM in nipype: https://nipype.readthedocs.io/en/latest/api/generated/nipype.algorithms.modelgen.html#module-nipype.algorithms.modelgen

So I did put them in the software options.

I will try to do the same for the model from our teams to see if I can make this work without turning it into a headache.
