### PR TITLE
Abstract base class for pipelines

### DIFF
--- a/docs/testing.md
+++ b/docs/testing.md
@@ -1,0 +1,31 @@
+# How to test NARPS open pipelines ?
+
+:mega: This file descripes the test suite and features for the project.
+
+## Dependancies
+
+Use *pylint* to run static code analysis.
+
+*[Pylint](http://pylint.pycqa.org/en/latest/) is a tool that checks for errors in Python code, tries to enforce a coding standard and looks for code smells. It can also look for certain type errors, it can recommend suggestions about how particular blocks can be refactored and can offer you details about the code's complexity.*
+
+* Run the analysis on all the source files with : `pylint ./narps_open`
+* To create a .xml JUnit report : `pylint --fail-under=8.0 --ignored-classes=_socketobject --load-plugins=pylint_junit --output-format=pylint_junit.JUnitReporter narps_open > pylint_report_narps_open.xml`
+
+Use [*pytest*](https://docs.pytest.org/en/6.2.x/contents.html) to run automatic testing and its [*pytest-cov*](https://pytest-cov.readthedocs.io/en/latest/) plugin to control code coverage.
+
+*The pytest framework makes it easy to write small tests, yet scales to support complex functional testing for applications and libraries.*
+
+Tests can be launched manually or while using CI (Continuous Integration).
+
+* To run the tests : `pytest ./tests`
+* To specify a test file to run : `pytest test_file.py`
+* To specify a test -for which the name contains 'test_pattern'- inside a test file : `pytest test_file.py -k "test_pattern"`
+* [CI] to output a xml JUnit test report, use the option : `--junit-xml=pytest_report.xml`
+* To create code coverage data : `coverage run -m pytest ./tests` then `coverage report` to see the code coverage result or `coverage xml` to output a .xml report file
+
+## Writing tests
+The main idea is to create one test file per source module (eg.: *tests/pipelines/test_pipelines.py* contains all the tests for the module `narps_open.pipelines`).
+
+Each test file defines a class (in the example: `TestPipelines`), in which each test is written in a static method begining with `test_`.
+
+Finally we use one or several `assert` ; each one of them making the whole test fail if the assertion is False. One can also use the `raises` method of pytest, writing `with raises(Exception):` to test if a piece of code raised the expected Exception. See the reference [here](https://docs.pytest.org/en/6.2.x/reference.html?highlight=raises#pytest.raises).

--- a/narps_open/pipelines/__init__.py
+++ b/narps_open/pipelines/__init__.py
@@ -1,0 +1,134 @@
+#!/usr/bin/python
+# coding: utf-8
+
+""" Interfaces that declare operations and parameters common to all pipelines. """
+
+from os.path import join, abspath
+from random import choices
+from abc import ABC, abstractmethod
+from argparse import ArgumentParser
+from importlib_resources import files
+
+class PipelineDirectories():
+    """ This object contains paths to the directories of interest for a Pipeline """
+
+    def __init__(self):
+        """ Attributes (properties) of class PipelineDirectories are:
+            - dataset_dir: str, directory where the ds001734 dataset is stored
+            (same for each inheriting pipeline)
+            - working_dir: str, directory where to store intermediate results
+            (will change for each inheriting pipeline)
+            - output_dir: str, directory for final results
+            (will change for each inheriting pipeline)
+
+            These 3 directories are based on the following 'private' attributes:
+            - _root_dir: str, absolute path of the root directory of the project
+            - _results_dir: str, base directory for results to be stored
+
+        """
+        # Find the root directory using importlib_resources' files()
+        self._root_dir = abspath(files('narps_open').joinpath('..'))
+        self._results_dir = join(self._root_dir, 'data', 'derived', 'reproduced')
+
+        # Initialize other directories
+        self._dataset_dir = join(self._root_dir, 'data', 'original', 'ds001734')
+        self._working_dir = ''
+        self._output_dir = ''
+
+    @property
+    def dataset_dir(self):
+        """ Getter for property exp_dir """
+        return self._dataset_dir
+
+    @property
+    def working_dir(self):
+        """ Getter for property working_dir """
+        return self._working_dir
+
+    @working_dir.setter
+    def working_dir(self, dir_name):
+        """ Setter for property working_dir """
+        self._working_dir = dir_name
+
+    @property
+    def output_dir(self):
+        """ Getter for property output_dir """
+        return self._output_dir
+
+    @output_dir.setter
+    def output_dir(self, dir_name):
+        """ Setter for property output_dir """
+        self._output_dir = dir_name
+
+    def setup(self, team_id: str = 'None') -> None:
+        """ Set the directories according to the team ID """
+        self._working_dir = join(
+            self._results_dir,f'NARPS-{team_id}-reproduced/intermediate_results')
+        self._output_dir = join(self._results_dir, f'NARPS-{team_id}-reproduced')
+
+class Pipeline(ABC):
+    """ An abstract class from which pipelines can inherit. """
+
+    @abstractmethod
+    def __init__(self):
+        """ Attributes of class Pipeline are:
+        # Directories
+            - directories: PipelineDirectories, an object that contains all the paths of interest
+            for the pipeline
+
+        # Lists of data
+            - subject_list: list of str, list of subject for which you want to do the analysis
+            - run_list: list of str, list of runs for which you want to do the analysis
+
+        # Parameters
+            - fwhm: float, Full width at half maximum (in mm) for the Gaussian smoothing kernel
+            - tr: float, time repetition (in s) used during acquisition. This value is the same
+            for all pipelines as they use the same dataset.
+        """
+        # Directories
+        self._directories = PipelineDirectories()
+
+        # Data
+        self._subject_list = []
+        self._run_list = []
+
+        # Parameters
+        self._fwhm = 0.0
+        self._tr = 1.0
+
+    @property
+    def directories(self):
+        """ Getter for property directories """
+        return self._directories
+
+    @directories.setter
+    def directories(self, value: PipelineDirectories):
+        """ Setter for property fwhm """
+        self._directories = value
+
+    @property
+    def tr(self):
+        """ Getter for property tr """
+        return self._tr
+
+    @property
+    def fwhm(self):
+        """ Getter for property fwhm """
+        return self._fwhm
+
+    @fwhm.setter
+    def fwhm(self, value):
+        """ Setter for property fwhm """
+        self._fwhm = value
+
+    @abstractmethod
+    def get_preprocessing(self):
+        """ Return a Nipype worflow describing the prerpocessing part of the pipeline """
+
+    @abstractmethod
+    def get_subject_level_analysis(self):
+        """ Return a Nipype worflow describing the subject level analysis part of the workflow """
+
+    @abstractmethod
+    def get_group_level_analysis(self):
+        """ Return a Nipype worflow describing the group level analysis part of the workflow """

--- a/setup.py
+++ b/setup.py
@@ -14,6 +14,7 @@ will add the current directory (.) to the system path.
 from setuptools import setup, find_packages
 
 requires = [
+    'importlib_resources>=5.10.2,<5.11',
 ]
 
 setup(

--- a/tests/pipelines/test_pipelines.py
+++ b/tests/pipelines/test_pipelines.py
@@ -1,0 +1,117 @@
+#!/usr/bin/python
+# coding: utf-8
+
+""" Tests of the 'pipelines' module.
+
+Launch this test with PyTest
+
+Usage:
+======
+    pytest -q test_pipelines.py
+    pytest -q test_pipelines.py -k <selected_test>
+"""
+
+from pytest import raises
+
+from narps_open.pipelines import PipelineDirectories, Pipeline
+
+class InheritingErrorPipeline(Pipeline):
+    """ A class to test the inheritance of the Pipeline class """
+
+class InheritingPipeline(Pipeline):
+    """ A class to test the inheritance of the Pipeline class """
+
+    def __init__(self):
+        super().__init__()
+
+        self.fwhm = 8.0
+
+    def get_preprocessing(self):
+        return 'a'
+
+    def get_subject_level_analysis(self):
+        return 'b'
+
+    def get_group_level_analysis(self):
+        return 'c'
+
+class TestPipelineDirectories:
+    """ A class that contains all the unit tests for the PipelineDirectories class."""
+
+    @staticmethod
+    def test_create():
+        """ Test the creation of a PipelineDirectories object """
+
+        # 1a - create the object
+        pipeline_dir = PipelineDirectories()
+
+        # 1b - 'hard writing' the class attributes for test purposes
+        pipeline_dir._dataset_dir = 'pipeline_dir._dataset_dir'
+        pipeline_dir._working_dir = 'pipeline_dir._working_dir'
+        pipeline_dir._output_dir = 'pipeline_dir._output_dir'
+
+        # 2 - check one can access the following attributes
+        #    - dataset_dir (get only)
+        #    - working_dir (get and set)
+        #    - output_dir (get and set)
+        assert pipeline_dir.dataset_dir == 'pipeline_dir._dataset_dir'
+        with raises(AttributeError):
+            pipeline_dir.dataset_dir = 'test_d'
+
+        assert pipeline_dir.working_dir == 'pipeline_dir._working_dir'
+        pipeline_dir.working_dir = 'test_w'
+        assert pipeline_dir.working_dir == 'test_w'
+
+        assert pipeline_dir.output_dir == 'pipeline_dir._output_dir'
+        pipeline_dir.output_dir = 'test'
+        assert pipeline_dir.output_dir == 'test'
+
+    @staticmethod
+    def test_setup():
+        """ Test the setup method of PipelineDirectories """
+
+        # 1a - create the object
+        pipeline_dir = PipelineDirectories()
+
+        # 1b - 'hard writing' the class attributes for test purposes
+        pipeline_dir._results_dir = 'pipeline_dir._results_dir'
+
+        # 2 - 
+        pipeline_dir.setup('team_id_test')
+        test_str = 'pipeline_dir._results_dir/NARPS-team_id_test-reproduced/intermediate_results'
+        assert pipeline_dir.working_dir == test_str
+        assert pipeline_dir.output_dir == 'pipeline_dir._results_dir/NARPS-team_id_test-reproduced'
+
+class TestPipelines:
+    """ A class that contains all the unit tests for the Pipeline class."""
+
+    @staticmethod
+    def test_create():
+        """ Test the creation of a Pipeline object """
+
+        # 1 - check that creating a Pipeline object is not possible (abstract class)
+        with raises(TypeError):
+            pipeline = Pipeline()
+
+        # 2 - check the instanciation of an incomplete class inheriting from Pipeline
+        with raises(TypeError):
+            pipeline = InheritingErrorPipeline()
+
+        # 3 - check the instanciation of a class inheriting from Pipeline
+        pipeline = InheritingPipeline()
+
+        # 4 - check accessing the attributes of Pipeline through an inheriting class
+        assert type(pipeline.directories) == PipelineDirectories
+
+        
+        assert pipeline.tr == 1.0
+        with raises(AttributeError):
+            pipeline.tr = 2.0
+
+        assert pipeline.fwhm == 8.0
+        pipeline.fwhm = 4.0
+        assert pipeline.fwhm == 4.0
+
+        assert pipeline.get_preprocessing() == 'a'
+        assert pipeline.get_subject_level_analysis() == 'b'
+        assert pipeline.get_group_level_analysis() == 'c'


### PR DESCRIPTION
1. [REFAC] :paintbrush: A base class for pipelines was created (it's called `Pipeline`), this allows :
    - to factorize features that are common to all pipelines
    - to make the launching of pipelines easier, exposing a unique interface
2. [TEST] :microscope: A class of unit tests for `Pipeline` was written
3. [DOC] :blue_book: The way of launching tests is now described in the documentation
