### PR TITLE
BUG solving : pipeline status

### DIFF
--- a/.github/workflows/pipeline_status.yml
+++ b/.github/workflows/pipeline_status.yml
@@ -54,6 +54,10 @@ jobs:
         cd wiki
         git config user.name github-actions
         git config user.email github-actions@github.com
-        git add .
-        git commit -m "Pipeline status updated"
-        git push
+
+        # Test if there are changes in the repository before commiting
+        if [[ $(git diff --name-only) ]]; then
+          git add .
+          git commit -m "Pipeline status updated"
+          git push
+        fi


### PR DESCRIPTION
# Changes proposed in this Pull Request

In the previous version, a bug was introduced in the `pipeline_status` workflow for GitHub Actions. Indeed when no changes are done in the pipeline status table, the CI job fails.

This PR propose a correction for this bug.
