### PR TITLE
[MAINT] add dependabot to update github actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,9 @@
+---
+# Documentation
+# https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
+version: 2
+updates:
+-   package-ecosystem: github-actions
+    directory: /
+    schedule:
+        interval: monthly


### PR DESCRIPTION
Closes None

Changes proposed in this Pull Request:

- add a dependabot config to keep github actions up to date

Checklist:

- [x] Descriptive title
- [x] Targets the `main` branch
- [x] Changes are functional
- [x] My code is explicit and comments were added to it
- [ ] Code conforms with PEP8
- [ ] Tests were added for the changes and they complete successfully
- [ ] Existing tests were updated (if needed) and they complete successfully
- [ ] Documentation was updated
