### PR TITLE
[UTILS] New utils function to compute voxel size for a volume

### DIFF
--- a/narps_open/utils/__init__.py
+++ b/narps_open/utils/__init__.py
@@ -193,7 +193,7 @@ def fmriprep_data_template() -> dict:
 
     return {"func_preproc": func_preproc, "confounds_file": confounds_file}
 
-def get_vox_dims(volume : list | str) -> list:
+def get_vox_dims(volume : list) -> list:
     ''' 
     Function that gives the voxel dimension of an image. 
     Not used here but if we use it, modify the connection to : 

--- a/narps_open/utils/__init__.py
+++ b/narps_open/utils/__init__.py
@@ -192,3 +192,27 @@ def fmriprep_data_template() -> dict:
     )
 
     return {"func_preproc": func_preproc, "confounds_file": confounds_file}
+
+def get_vox_dims(volume : list | str) -> list:
+    ''' 
+    Function that gives the voxel dimension of an image. 
+    Not used here but if we use it, modify the connection to : 
+    (?, normalize_func, [('?', 'apply_to_files'),
+                                    (('?', get_vox_dims),
+                                     'write_voxel_sizes')])
+
+    Args:
+        volume: list | str
+            List of str or str that represent a path to a Nifti image. 
+
+    Returns: 
+        list: 
+            size of the voxels in the volume or in the first volume of the list.
+    '''
+    import nibabel as nb
+    if isinstance(volume, list):
+        volume = volume[0]
+    nii = nb.load(volume)
+    hdr = nii.header
+    voxdims = hdr.get_zooms()
+    return [float(voxdims[0]), float(voxdims[1]), float(voxdims[2])]


### PR DESCRIPTION
This Pull Request is related to issue [#](add a link to the issue here).

Before reviewing this Pull Request, please review Pull Request [#](add a link to the Pull Request here).

Changes proposed in this Pull Request:

- Add a utils function `get_vox_dims` that can be used in pre-processing pipelines to get the size of voxels. 
- Don't really know where to add the documentation? 
- 

Checklist:

- [x] Descriptive title
- [x] Targets the `main` branch
- [x] Changes are functional
- [x] My code is explicit and comments were added to it
- [x] Code conforms with PEP8
- [x] Tests were added for the changes and they complete successfully
- [x] Existing tests were updated (if needed) and they complete successfully
- [x] Documentation was updated
