### PR TITLE
Entry points accept configuration files at runtime

### DIFF
--- a/.github/workflows/code_quality.yml
+++ b/.github/workflows/code_quality.yml
@@ -25,10 +25,10 @@ jobs:
     # Steps that define the job
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
 
     - name: Set up Python
-      uses: actions/setup-python@v3
+      uses: actions/setup-python@v4
       with:
         python-version: 3.9
 
@@ -50,7 +50,7 @@ jobs:
         pylint --fail-under 8 tests > pylint_report_tests.txt
 
     - name: Archive pylint results
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       if: failure() # Only if previous step failed
       with:
         name: pylint-reports-python

--- a/.github/workflows/codespell.yml
+++ b/.github/workflows/codespell.yml
@@ -17,6 +17,6 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Codespell
         uses: codespell-project/actions-codespell@v2

--- a/.github/workflows/pipeline_status.yml
+++ b/.github/workflows/pipeline_status.yml
@@ -22,18 +22,18 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout main branch
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         ref: main
 
     - name: Checkout wiki
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         repository: ${{github.repository}}.wiki
         path: wiki
 
     - name: Set up Python 3.9
-      uses: actions/setup-python@v3
+      uses: actions/setup-python@v4
       with:
         python-version: 3.9
 

--- a/docs/data.md
+++ b/docs/data.md
@@ -88,6 +88,7 @@ narps_results -h
                             a list of team IDs
       -a, --all             download results from all teams
       -r, --rectify         rectify the results
+      --config CONFIG       custom configuration file to be used
 
 # Either download all collections
 narps_results -a

--- a/docs/description.md
+++ b/docs/description.md
@@ -28,6 +28,7 @@ narps_description -h
 #                         the sub dictionary of team description
 #  --json                output team description as JSON
 #  --md                  output team description as Markdown
+#  --config CONFIG       custom configuration file to be used
 
 narps_description -t 2T6S --json
 # {

--- a/docs/running.md
+++ b/docs/running.md
@@ -30,6 +30,7 @@ narps_open_runner -h
 	                        the analysis levels to run (p=preprocessing, r=run, s=subject, g=group)
 	  -c, --check           check pipeline outputs (runner is not launched)
 	  -e, --exclusions      run the analyses without the excluded subjects
+	  --config CONFIG       custom configuration file to be used
 
 narps_open_runner -t 2T6S -s 001 006 020 100 # Launches the full pipeline on the given subjects
 narps_open_runner -t 2T6S -r 4 # Launches the full pipeline on 4 random subjects

--- a/docs/status.md
+++ b/docs/status.md
@@ -59,6 +59,7 @@ narps_open_status -h
 #   -h, --help  show this help message and exit
 #   --json      output the report as JSON
 #   --md        output the report as Markdown
+#   --config CONFIG  custom configuration file to be used
 
 narps_open_status --json
 # {

--- a/narps_open/data/description/__main__.py
+++ b/narps_open/data/description/__main__.py
@@ -30,7 +30,13 @@ def main():
     formats = parser.add_mutually_exclusive_group(required = False)
     formats.add_argument('--json', action='store_true', help='output team description as JSON')
     formats.add_argument('--md', action='store_true', help='output team description as Markdown')
+    parser.add_argument('--config', type=str, required=False,
+        help='custom configuration file to be used')
     arguments = parser.parse_args()
+
+    # Init configuration
+    if arguments.config:
+        Configuration('custom').config_file = arguments.config
 
     # Initialize a TeamDescription
     information = TeamDescription(team_id = arguments.team)

--- a/narps_open/data/results/__main__.py
+++ b/narps_open/data/results/__main__.py
@@ -19,8 +19,15 @@ def main():
     group.add_argument('-a', '--all', action='store_true', help='download results from all teams')
     parser.add_argument('-r', '--rectify', action='store_true', default = False, required = False,
         help='rectify the results')
+    parser.add_argument('--config', type=str, required=False,
+        help='custom configuration file to be used')
     arguments = parser.parse_args()
 
+    # Init configuration
+    if arguments.config:
+        Configuration('custom').config_file = arguments.config
+
+    # Start collecting result data
     factory = ResultsCollectionFactory()
 
     if arguments.all:

--- a/narps_open/runner.py
+++ b/narps_open/runner.py
@@ -209,6 +209,8 @@ def main():
 
     # Parse arguments
     parser = ArgumentParser(description='Run the pipelines from NARPS.')
+    parser.add_argument('--config', type=str, required=False,
+        help='custom configuration file to be used')
     parser.add_argument('-t', '--team', type=str, required=True,
         help='the team ID', choices=get_implemented_pipelines())
     subjects = parser.add_mutually_exclusive_group(required=True)
@@ -232,6 +234,10 @@ def main():
     if arguments.exclusions and not arguments.nsubjects:
         print('Argument -e/--exclusions only works with -n/--nsubjects')
         return
+
+    # Init configuration
+    if arguments.config:
+        Configuration('custom').config_file = arguments.config
 
     # Initialize a PipelineRunner
     runner = PipelineRunner(team_id = arguments.team)

--- a/narps_open/runner.py
+++ b/narps_open/runner.py
@@ -209,8 +209,6 @@ def main():
 
     # Parse arguments
     parser = ArgumentParser(description='Run the pipelines from NARPS.')
-    parser.add_argument('--config', type=str, required=False,
-        help='custom configuration file to be used')
     parser.add_argument('-t', '--team', type=str, required=True,
         help='the team ID', choices=get_implemented_pipelines())
     subjects = parser.add_mutually_exclusive_group(required=True)
@@ -228,6 +226,8 @@ def main():
         help='check pipeline outputs (runner is not launched)')
     parser.add_argument('-e', '--exclusions', action='store_true', required=False,
         help='run the analyses without the excluded subjects')
+    parser.add_argument('--config', type=str, required=False,
+        help='custom configuration file to be used')
     arguments = parser.parse_args()
 
     # Check arguments

--- a/narps_open/utils/configuration/docker_config.toml
+++ b/narps_open/utils/configuration/docker_config.toml
@@ -1,0 +1,18 @@
+[general]
+title = "Configuration for the NARPS open pipelines project, to be used inside the nipype/nipype:py38 docker container"
+config_type = "custom"
+
+[directories]
+dataset = "/work/data/original/ds001734/"
+reproduced_results = "/work/run/reproduced/"
+narps_results = "/work/data/results/"
+
+[runner]
+nb_procs = 8 # Maximum number of threads executed by the runner
+nb_trials = 3 # Maximum number of executions to have the pipeline executed completely
+
+[pipelines]
+remove_unused_data = true # set to true to activate remove nodes of pipelines
+
+[results]
+neurovault_naming = true # true if results files are saved using the neurovault naming, false if they use naming of narps

--- a/narps_open/utils/correlation/__main__.py
+++ b/narps_open/utils/correlation/__main__.py
@@ -21,7 +21,13 @@ def main():
         help = 'the team ID', choices = get_implemented_pipelines())
     parser.add_argument('-n', '--nsubjects', type = int, required = True,
         help='the number of subjects to be selected')
+    parser.add_argument('--config', type=str, required=False,
+        help='custom configuration file to be used')
     arguments = parser.parse_args()
+
+    # Init configuration
+    if arguments.config:
+        Configuration('custom').config_file = arguments.config
 
     # Initialize pipeline
     runner = PipelineRunner(arguments.team)

--- a/narps_open/utils/status.py
+++ b/narps_open/utils/status.py
@@ -197,8 +197,15 @@ def main():
     formats = parser.add_mutually_exclusive_group(required = False)
     formats.add_argument('--json', action='store_true', help='output the report as JSON')
     formats.add_argument('--md', action='store_true', help='output the report as Markdown')
+    parser.add_argument('--config', type=str, required=False,
+        help='custom configuration file to be used')
     arguments = parser.parse_args()
 
+    # Init configuration
+    if arguments.config:
+        Configuration('custom').config_file = arguments.config
+
+    # Generate report
     report = PipelineStatusReport()
     report.generate()
 


### PR DESCRIPTION
Changes proposed in this Pull Request:

- Entry points `narps_description`, `narps_open_runner`, `narps_results`, `narps_open_correlations`, `narps_open_status` have a new `--config` parameter to pass a custom configuration file at runtime. This behavior was already implemented in the `narps_open.utils.configuration` module but the entry points were not using it.
- Documentation update

Checklist:

- [x] Descriptive title
- [x] Targets the `main` branch
- [x] Changes are functional
- [x] My code is explicit and comments were added to it
- [x] Code conforms with PEP8
- [x] Tests were added for the changes and they complete successfully
- [x] Existing tests were updated (if needed) and they complete successfully
- [x] Documentation was updated
